### PR TITLE
Add rustfmt.toml and run rustfmt against code

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,8 @@
+fn_call_width = 80
+struct_trailing_comma = "Never"
+struct_lit_trailing_comma = "Never"
+enum_trailing_comma = false
+match_wildcard_trailing_comma = false
+type_punctuation_density = "Compressed"
+wrap_match_arms = false
+use_try_shorthand = true

--- a/src/arbitrary.rs
+++ b/src/arbitrary.rs
@@ -11,7 +11,7 @@ impl Arbitrary for Path {
         let range = Range::new(1u8, 4u8);
         let depth = range.ind_sample(g);
         let labels = ['a', 'b', 'c', 'd', 'e'];
-        let mut path = String::with_capacity((depth*2 - 1) as usize);
+        let mut path = String::with_capacity((depth * 2 - 1) as usize);
         path = (0..depth).fold(path, |mut acc, _| {
             acc.push('/');
             acc.push(*g.choose(&labels).unwrap());
@@ -24,6 +24,7 @@ impl Arbitrary for Path {
 impl Arbitrary for NodeType {
     fn arbitrary<G: Gen>(g: &mut G) -> NodeType {
         g.choose(&[NodeType::Directory, NodeType::Queue, NodeType::Set, NodeType::Blob])
-            .unwrap().clone()
+            .unwrap()
+            .clone()
     }
 }

--- a/src/cas.rs
+++ b/src/cas.rs
@@ -12,14 +12,14 @@ pub struct Guard {
 /// A write operation that is part of a multi-cas
 #[derive(Debug, Clone)]
 pub enum WriteOp {
-    CreateNode {path: String, ty: NodeType},
-    DeleteNode {path: String},
-    BlobPut {path: String, val: Vec<u8>},
-    QueuePush {path: String, val: Vec<u8>},
-    QueuePop {path: String},
-    SetInsert {path: String, val: Vec<u8>},
-    SetRemove {path: String, val: Vec<u8>},
-    Snapshot {directory: String}
+    CreateNode { path: String, ty: NodeType },
+    DeleteNode { path: String },
+    BlobPut { path: String, val: Vec<u8> },
+    QueuePush { path: String, val: Vec<u8> },
+    QueuePop { path: String },
+    SetInsert { path: String, val: Vec<u8> },
+    SetRemove { path: String, val: Vec<u8> },
+    Snapshot { directory: String }
 }
 
 #[cfg(test)]
@@ -32,6 +32,7 @@ mod tests {
     use rand::distributions::IndependentSample;
     use arbitrary::Path;
 
+    #[cfg_attr(rustfmt, rustfmt_skip)]
     impl Arbitrary for WriteOp {
         fn arbitrary<G: Gen>(g: &mut G) -> WriteOp {
             let range = Range::new(1u8, 8u8);
@@ -66,15 +67,16 @@ mod tests {
 
     /// Any op that doesn't succeed on it's own is removed from the list
     fn filter_by_valid<'a>(ops: Vec<WriteOp>) -> (Vec<WriteOp>, Vec<Reply>, Tree) {
-        ops.into_iter().fold((Vec::new(), Vec::new(), Tree::new()), |(mut ops, mut replies, tree), op| {
-            match tree.multi_cas(vec![], vec![op.clone()]) {
-                Ok((new_replies, new_tree)) => {
-                    ops.push(op);
-                    replies.extend(new_replies);
-                    (ops, replies, new_tree)
-                },
-                Err(_) => (ops, replies, tree)
-            }
-        })
+        ops.into_iter()
+            .fold((Vec::new(), Vec::new(), Tree::new()), |(mut ops, mut replies, tree), op| {
+                match tree.multi_cas(vec![], vec![op.clone()]) {
+                    Ok((new_replies, new_tree)) => {
+                        ops.push(op);
+                        replies.extend(new_replies);
+                        (ops, replies, new_tree)
+                    }
+                    Err(_) => (ops, replies, tree),
+                }
+            })
     }
 }

--- a/src/containers/mod.rs
+++ b/src/containers/mod.rs
@@ -11,4 +11,3 @@ pub enum Container {
     Queue(Queue),
     Set(Set)
 }
-

--- a/src/containers/queue.rs
+++ b/src/containers/queue.rs
@@ -7,15 +7,11 @@ pub struct Queue {
 
 impl Queue {
     pub fn new() -> Queue {
-        Queue {
-            data: VecDeque::new()
-        }
+        Queue { data: VecDeque::new() }
     }
 
     pub fn with_capacity(size: usize) -> Queue {
-        Queue {
-            data: VecDeque::with_capacity(size)
-        }
+        Queue { data: VecDeque::with_capacity(size) }
     }
 
     /// Append an element onto the back of the queue
@@ -63,8 +59,7 @@ mod tests {
         let res1 = q1.pop();
         match res1 {
             Some(r1) => assert_eq!(r1, blob1),
-            None => panic!("got None, expected Some for res1")
+            None => panic!("got None, expected Some for res1"),
         }
     }
 }
-

--- a/src/containers/set.rs
+++ b/src/containers/set.rs
@@ -13,21 +13,15 @@ pub struct Set {
 /// [commit](https://github.com/rust-lang/rust/pull/35091).
 impl Set {
     pub fn new() -> Set {
-        Set {
-            data: HashSet::new()
-        }
+        Set { data: HashSet::new() }
     }
 
     pub fn with_capacity(size: usize) -> Set {
-        Set {
-            data: HashSet::with_capacity(size)
-        }
+        Set { data: HashSet::with_capacity(size) }
     }
 
     pub fn fill(data: HashSet<Vec<u8>>) -> Set {
-        Set {
-            data: data
-        }
+        Set { data: data }
     }
 
     /// Insert an element into the set.
@@ -47,15 +41,15 @@ impl Set {
         self.data.contains(element)
     }
 
-     /// Returns the number of elements in the Set
-     pub fn len(&self) -> usize {
-       self.data.len()
-     }
-     
-     /// Returns `true` if the `Set` is empty
-     pub fn is_empty(&self) -> bool {
-     	self.data.is_empty()
-     }
+    /// Returns the number of elements in the Set
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns `true` if the `Set` is empty
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
 
 
     /// Returns the union of two sets
@@ -70,7 +64,7 @@ impl Set {
     ///
     /// assert_eq!(Set { data: a.union(&b).cloned().collect() },
     ///            Set { data: vec![vec![1], vec![2], vec![3], vec![4]].into_iter().collect() });
-    pub fn union<'a>(&'a self, other: &'a Set) -> impl Iterator<Item=&'a Vec<u8>> {
+    pub fn union<'a>(&'a self, other: &'a Set) -> impl Iterator<Item = &'a Vec<u8>> {
         self.data.union(&other.data)
     }
 
@@ -86,7 +80,7 @@ impl Set {
     ///
     /// let result = Set { data: a.intersection(&b).cloned().collect() };
     /// assert_eq!(result, Set { data: vec![vec![2], vec![3]].into_iter().collect() });
-    pub fn intersection<'a>(&'a self, other: &'a Set) -> impl Iterator<Item=&'a Vec<u8>> {
+    pub fn intersection<'a>(&'a self, other: &'a Set) -> impl Iterator<Item = &'a Vec<u8>> {
         self.data.intersection(&other.data)
     }
 
@@ -105,7 +99,7 @@ impl Set {
     ///
     /// let result = Set { data: a.difference(&b).cloned().collect() };
     /// assert_eq!(result, Set { data: vec![vec![1]].into_iter().collect() });
-    pub fn difference<'a>(&'a self, other: &'a Set) -> impl Iterator<Item=&'a Vec<u8>> {
+    pub fn difference<'a>(&'a self, other: &'a Set) -> impl Iterator<Item = &'a Vec<u8>> {
         self.data.difference(&other.data)
     }
 
@@ -127,7 +121,7 @@ impl Set {
     /// assert_eq!(result_a, result_b);
     /// assert_eq!(result_a,
     ///            Set { data: vec![vec![1], vec![4]].into_iter().collect() });
-    pub fn symmetric_difference<'a>(&'a self, other: &'a Set) -> impl Iterator<Item=&'a Vec<u8>> {
+    pub fn symmetric_difference<'a>(&'a self, other: &'a Set) -> impl Iterator<Item = &'a Vec<u8>> {
         self.data.symmetric_difference(&other.data)
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -51,7 +51,7 @@ impl Content {
             NodeType::Directory => Content::Directory(vec![]),
             NodeType::Blob => Content::Container(Container::Blob(Vec::new())),
             NodeType::Queue => Content::Container(Container::Queue(Queue::new())),
-            NodeType::Set => Content::Container(Container::Set(Set::new()))
+            NodeType::Set => Content::Container(Container::Set(Set::new())),
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -88,7 +88,10 @@ impl Tree {
 
             depth += 1;
         }
-        Ok(Tree {root: root, depth: depth})
+        return Ok(Tree {
+            root: root,
+            depth: depth
+        });
     }
 
     pub fn delete(&self, path: &str) -> Result<(u64, Tree)> {
@@ -98,18 +101,17 @@ impl Tree {
 
         let label = match Path::new(path).file_name() {
             Some(label) => label.to_str().unwrap(),
-            None => return Err(ErrorKind::BadPath(path.to_string()).into())
+            None => return Err(ErrorKind::BadPath(path.to_string()).into()),
         };
-        let parent = match Path::new(path).parent() {
-            Some(parent) =>  parent.to_str().unwrap(),
-            None => return Err(ErrorKind::PathMustBeAbsolute(path.to_string()).into())
+        let parent = match Path::new(path.clone()).parent() {
+            Some(parent) => parent.to_str().unwrap(),
+            None => return Err(ErrorKind::PathMustBeAbsolute(path.to_string()).into()),
         };
 
         let (node, tree) = self.find_mut(parent, NodeType::Directory)?;
         if let Content::Directory(ref mut edges) = node.content {
-            let index = edges.binary_search_by_key(&label, |e| &e.label).map_err(|_| {
-                Error::from(ErrorKind::DoesNotExist(path.to_string()))
-            })?;
+            let index = edges.binary_search_by_key(&label, |e| &e.label)
+                .map_err(|_| Error::from(ErrorKind::DoesNotExist(path.to_string())))?;
             let deleted = edges.remove(index);
             return Ok((deleted.node.version, tree));
         }
@@ -163,17 +165,19 @@ impl Tree {
         let mut tree = self.clone();
         for op in ops {
             tree = match op {
-                WriteOp::CreateNode {path, ty} => {
+                WriteOp::CreateNode { path, ty } => {
                     let new_tree = tree.create(&path, ty)?;
-                    let version = { new_tree.root.version };
+                    let version = {
+                        new_tree.root.version
+                    };
                     replies.push(Reply {
                         path: Some("/".to_string()),
                         version: Some(version),
                         value: Value::None
                     });
                     new_tree
-                },
-                WriteOp::DeleteNode{path} => {
+                }
+                WriteOp::DeleteNode { path } => {
                     let (version, new_tree) = tree.delete(&path)?;
                     replies.push(Reply {
                         path: Some(path),
@@ -181,35 +185,37 @@ impl Tree {
                         value: Value::None
                     });
                     new_tree
-                },
-                WriteOp::BlobPut {path, val} => {
+                }
+                WriteOp::BlobPut { path, val } => {
                     let (reply, new_tree) = tree.blob_put(path, val)?;
                     replies.push(reply);
                     new_tree
-                },
-                WriteOp::QueuePush {path, val} => {
+                }
+                WriteOp::QueuePush { path, val } => {
                     let (reply, new_tree) = tree.queue_push(path, val)?;
                     replies.push(reply);
                     new_tree
-                },
-                WriteOp::QueuePop {path} => {
+                }
+                WriteOp::QueuePop { path } => {
                     let (reply, new_tree) = tree.queue_pop(path)?;
                     replies.push(reply);
                     new_tree
-                },
-                WriteOp::SetInsert {path, val} => {
+                }
+                WriteOp::SetInsert { path, val } => {
                     let (reply, new_tree) = tree.set_insert(path, val)?;
                     replies.push(reply);
                     new_tree
-                },
-                WriteOp::SetRemove {path, val} => {
+                }
+                WriteOp::SetRemove { path, val } => {
                     let (reply, new_tree) = tree.set_remove(path, val)?;
                     replies.push(reply);
                     new_tree
-                },
-                WriteOp::Snapshot {directory} => {
+                }
+                WriteOp::Snapshot { directory } => {
                     let _ = tree.snapshot(&directory)?;
-                    let version = { tree.root.version };
+                    let version = {
+                        tree.root.version
+                    };
                     replies.push(Reply {
                         path: Some("/".to_string()),
                         version: Some(version),
@@ -225,13 +231,17 @@ impl Tree {
     fn check_guards(&self, mut guards: Vec<Guard>) -> Result<()> {
         guards.sort_by_key(|g| g.path.clone());
         guards.dedup_by_key(|g| g.path.clone());
-        let (paths, versions): (Vec<_>, Vec<_>) = guards.iter().map(|g| (&g.path as &str, g.version)).unzip();
+        let (paths, versions): (Vec<_>, Vec<_>) =
+            guards.iter().map(|g| (&g.path as &str, g.version)).unzip();
         for (node, version) in self.path_iter(paths).zip(versions) {
             let node = node?;
             if node.version != version {
-                return Err(ErrorKind::CasFailed {path: node.path.clone(),
-                                                 expected: version,
-                                                 actual: node.version}.into());
+                return Err(ErrorKind::CasFailed {
+                        path: node.path.clone(),
+                        expected: version,
+                        actual: node.version
+                    }
+                    .into());
             }
         }
         Ok(())
@@ -272,7 +282,7 @@ impl Tree {
         let reply = Reply {
             path: Some(path),
             version: Some(version),
-            value: queue.pop().map_or(Value::Empty, Value::Blob),
+            value: queue.pop().map_or(Value::Empty, Value::Blob)
         };
         Ok((reply, tree))
     }
@@ -332,7 +342,7 @@ impl Tree {
             let normalized = validate_path(&path)?;
             self.find_blob(normalized)?
         };
-        Ok(Reply  {
+        Ok(Reply {
             path: Some(path),
             version: Some(version),
             value: Value::Int(blob.len() as u64)
@@ -390,52 +400,45 @@ impl Tree {
     pub fn set_subset(&self,
                       path1: String,
                       path2: Option<String>,
-                      set: Option<HashSet<Vec<u8>>>) -> Result<Reply> {
+                      set: Option<HashSet<Vec<u8>>>)
+                      -> Result<Reply> {
         let normalized = validate_path(&path1)?;
-        self.subset_or_superset("Subset", normalized, path2, set, |set1, set2| {
-            set1.is_subset(set2)
-        })
+        self.subset_or_superset("Subset", normalized, path2, set, |set1, set2| set1.is_subset(set2))
     }
 
     pub fn set_superset(&self,
                         path1: String,
                         path2: Option<String>,
-                        set: Option<HashSet<Vec<u8>>>) -> Result<Reply> {
+                        set: Option<HashSet<Vec<u8>>>)
+                        -> Result<Reply> {
         let normalized = validate_path(&path1)?;
-        self.subset_or_superset("Superset", normalized, path2, set, |set1, set2| {
-            set1.is_superset(set2)
-        })
+        self.subset_or_superset("Superset",
+                                normalized,
+                                path2,
+                                set,
+                                |set1, set2| set1.is_superset(set2))
     }
 
     pub fn set_union(&self, paths: Vec<String>, sets: Vec<HashSet<Vec<u8>>>) -> Result<Reply> {
-        self.set_op(paths, sets, |set1, set2| {
-            Set::fill(set1.union(set2).map(|s| s.to_vec()).collect())
-        })
+        self.set_op(paths,
+                    sets,
+                    |set1, set2| Set::fill(set1.union(set2).map(|s| s.to_vec()).collect()))
     }
 
-    pub fn set_intersection(&self,
-                            path1: &str,
-                            path2: &str) -> Result<Reply>
-    {
+    pub fn set_intersection(&self, path1: &str, path2: &str) -> Result<Reply> {
         self.binary_set_op(path1, path2, |set1, set2| {
             Set::fill(set1.intersection(set2).map(|s| s.to_vec()).collect())
         })
     }
 
-    pub fn set_difference(&self,
-                          path1: &str,
-                          path2: &str) -> Result<Reply>
-    {
+    pub fn set_difference(&self, path1: &str, path2: &str) -> Result<Reply> {
 
         self.binary_set_op(path1, path2, |set1, set2| {
             Set::fill(set1.difference(set2).map(|s| s.to_vec()).collect())
         })
     }
 
-    pub fn set_symmetric_difference(&self,
-                                    path1: &str,
-                                    path2: &str) -> Result<Reply>
-    {
+    pub fn set_symmetric_difference(&self, path1: &str, path2: &str) -> Result<Reply> {
         self.binary_set_op(path1, path2, |set1, set2| {
             Set::fill(set1.symmetric_difference(set2).map(|s| s.to_vec()).collect())
         })
@@ -447,13 +450,16 @@ impl Tree {
                              path1: &str,
                              path2: Option<String>,
                              set: Option<HashSet<Vec<u8>>>,
-                             f: F) -> Result<Reply>
+                             f: F)
+                             -> Result<Reply>
         where F: Fn(&Set, &Set) -> bool
     {
 
         if path2.is_some() && set.is_some() {
             return Err(format!("{} can only operate on 2 sets.
-                                One of `path2` or `set` must be `None`", op).into())
+                                One of `path2` or `set` must be `None`",
+                               op)
+                .into());
         }
         let (set1, _) = self.find_set(path1)?;
 
@@ -473,7 +479,7 @@ impl Tree {
             path: None,
             version: None,
             value: Value::Bool(val)
-           })
+        })
     }
 
     fn binary_set_op<F>(&self, path1: &str, path2: &str, f: F) -> Result<Reply>
@@ -566,7 +572,7 @@ impl Tree {
                         if iter.peek().is_none() {
                             let node = &(*edges.get_unchecked(index).node);
                             verify_type(node, ty)?;
-                            return Ok((&node.content, node.version))
+                            return Ok((&node.content, node.version));
                         }
                         parent = &edges.get_unchecked(index).node;
                         continue;
@@ -588,8 +594,12 @@ impl Tree {
         let mut node = root.clone();
         if path == "/" {
             unsafe {
-            	let ptr: *mut Node = &*node as *const Node as *mut Node;
-                return Ok((&mut *ptr, Tree {root: root, depth: self.depth}))
+                let ptr: *mut Node = &*node as *const Node as *mut Node;
+                return Ok((&mut *ptr,
+                           Tree {
+                               root: root,
+                               depth: self.depth
+                           }));
             }
         }
         // Trim leading empty strings and stop iterating at the first empty string after a valid string
@@ -605,7 +615,11 @@ impl Tree {
                         let ptr: *mut Node = &*node as *const Node as *mut Node;
                         if iter.peek().is_none() {
                             verify_type(&*ptr, ty)?;
-                            return Ok((&mut *ptr, Tree {root: root, depth: self.depth}))
+                            return Ok((&mut *ptr,
+                                       Tree {
+                                           root: root,
+                                           depth: self.depth
+                                       }));
                         }
                     } else {
                         let path = join_path(&node.path, s);
@@ -645,8 +659,7 @@ fn join_path(dir_path: &str, label: &str) -> String {
     path
 }
 
-unsafe fn insert_dir(parent: Arc<Node>, label: &str) -> Result<Arc<Node>>
-{
+unsafe fn insert_dir(parent: Arc<Node>, label: &str) -> Result<Arc<Node>> {
     let ptr: *mut Node = &*parent as *const Node as *mut Node;
     if let Content::Directory(ref mut edges) = (*ptr).content {
         match edges.binary_search_by_key(&label, |e| &e.label) {
@@ -660,7 +673,7 @@ unsafe fn insert_dir(parent: Arc<Node>, label: &str) -> Result<Arc<Node>>
                 let node = cow_node(&child.node);
                 child.node = node.clone();
                 return Ok(node);
-            },
+            }
             Err(index) => {
                 let content = Content::new(NodeType::Directory);
                 // Edge doesn't exist, let's create it in the proper sort position
@@ -695,13 +708,13 @@ unsafe fn insert_leaf(parent: Arc<Node>, label: &str, ty: NodeType) -> Result<()
 ///
 /// Strip leading and trailing slashes and return normalized path as String
 fn validate_path(path: &str) -> Result<&str> {
-    if !path.starts_with('/') {
-        return Err(ErrorKind::BadPath(format!("{} does not start with a '/'", path)).into())
+    if !path.starts_with("/") {
+        return Err(ErrorKind::BadPath(format!("{} does not start with a '/'", path)).into());
     }
     let path = path.trim_matches('/');
     if path.is_empty() {
         return Err(ErrorKind::BadPath("Path must contain at least one component".to_string())
-                   .into());
+            .into());
     }
     Ok(path)
 }


### PR DESCRIPTION
The config is not perfectly matched to my personal style, as rustfmt is
missing options allowing full configurability. There are still trailing
commas on match blocks where the resulting expression is bound to a
variable using `let` and it doesn't seem possible to get rid of them.
There are other places, like a space between braces in struct literals
and the first character, that also don't seem configurable. However, I'm
willing to live with these slight style disagreements in order to have
the benefit of machine checking.

Here is a proposed configuration for rustfmt and the resulting output.
The escape hatch to prevent mangling: `#[cfg_attr(rustfmt, rustfmt_skip)]`
was only used once, in an effort to visually compress a match statement.