### PR TITLE
Add a travis-ci config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: rust
+cache: cargo
+rust:
+  - stable
+  - beta
+  - nightly
+script:
+  - cargo build --verbose
+  - cargo test --verbose


### PR DESCRIPTION
This allows vertree to have it's unit tests be run by https://travis-ci.org/.